### PR TITLE
Add velocity and volatility to the attributes for pivotal projects [#100773968]

### DIFF
--- a/lib/active_pivot/api/paginated_collection.rb
+++ b/lib/active_pivot/api/paginated_collection.rb
@@ -28,7 +28,7 @@ module ActivePivot
 
         (2..total_pages).map do |page|
           offset = limit * (page - 1)
-          Request.get(endpoint, params.merge(offset: offset))
+          send_request(params.merge(offset: offset))
         end
       end
 
@@ -37,8 +37,21 @@ module ActivePivot
       end
 
       def first_page
-        @first_page ||= Request.get(endpoint, params)
+        @first_page ||= send_request(params)
+      end
+
+      def send_request(params = {})
+        Request.get(endpoint, params).tap do |response|
+          raise_request_error unless response.success?
+        end
+      end
+
+      def raise_request_error
+        raise InvalidRequestError,
+          "Pivotal request failed. Endpoint #{endpoint} invalid with params: #{params}"
       end
     end
+
+    class InvalidRequestError < StandardError; end
   end
 end

--- a/lib/active_pivot/api/project.rb
+++ b/lib/active_pivot/api/project.rb
@@ -2,7 +2,7 @@ module ActivePivot
   module Api
     class Project < OpenStruct
       def self.all
-        Api::PaginatedCollection.new("/services/v5/projects.json").all.map do |remote_project|
+        Api::PaginatedCollection.new("/services/v5/projects.json?fields=:default,current_velocity,current_volatility").all.map do |remote_project|
           self.new(remote_project) rescue nil
         end.compact
       end

--- a/lib/active_pivot/api/project.rb
+++ b/lib/active_pivot/api/project.rb
@@ -1,10 +1,12 @@
 module ActivePivot
   module Api
     class Project < OpenStruct
+      COLLECTION_URL = "/services/v5/projects.json?fields=:default,current_velocity,current_volatility"
+
       def self.all
-        Api::PaginatedCollection.new("/services/v5/projects.json?fields=:default,current_velocity,current_volatility").all.map do |remote_project|
-          self.new(remote_project) rescue nil
-        end.compact
+        Api::PaginatedCollection.new(COLLECTION_URL).all.map do |remote_project|
+          self.new(remote_project)
+        end
       end
     end
   end

--- a/lib/active_pivot/importer.rb
+++ b/lib/active_pivot/importer.rb
@@ -5,9 +5,13 @@ module ActivePivot
     end
 
     def run
+      puts "Importing Projects"
       import_projects
+      puts "Importing Epics"
       import_epics
+      puts "Importing Stories"
       import_stories
+      puts "Importing Activity - may take up to 10 minutes"
       import_activities
     end
 

--- a/lib/active_pivot/importer.rb
+++ b/lib/active_pivot/importer.rb
@@ -18,8 +18,10 @@ module ActivePivot
         ActivePivot::Project.where(pivotal_id: remote_project.id)
           .first_or_initialize
           .update_attributes!({
-            name:        remote_project.name,
-            point_scale: remote_project.point_scale
+            name:               remote_project.name,
+            point_scale:        remote_project.point_scale,
+            current_velocity:   remote_project.current_velocity,
+            current_volatility: remote_project.current_volatility
           })
       end
     end

--- a/lib/generators/active_pivot/migrations_generator.rb
+++ b/lib/generators/active_pivot/migrations_generator.rb
@@ -2,7 +2,7 @@ module ActivePivot
   module Generators
     class MigrationsGenerator < ::Rails::Generators::Base
       def create_all
-        generate "migration", "create_pivotal_projects pivotal_id:integer name:text point_scale:text updated_at:datetime created_at:datetime"
+        generate "migration", "create_pivotal_projects pivotal_id:integer name:text point_scale:text current_velocity:integer current_volatility:integer updated_at:datetime created_at:datetime"
         generate "migration", "create_pivotal_epics project_id:integer:index pivotal_id:integer label_id:integer name:string url:string updated_at:datetime created_at:datetime"
         generate "migration", "create_pivotal_stories pivotal_id:integer project_id:integer:index started_at:datetime accepted_at:datetime url:string estimate:integer name:text description:text kind:string story_type:string labels:text current_state:string tags:text[] updated_at:datetime created_at:datetime"
         generate "migration", "create_pivotal_epic_stories story_id:integer:index epic_id:integer:index updated_at:datetime created_at:datetime"


### PR DESCRIPTION
Velocity and volatility are not included by default in requests for pivotal projects.
Added it to the GET request, store it, update migration generator

![](http://giant.gfycat.com/ImpossibleIndelibleGuineapig.gif)
