### PR TITLE
Allow activity importing to continue after error

### DIFF
--- a/lib/active_pivot/api/paginated_collection.rb
+++ b/lib/active_pivot/api/paginated_collection.rb
@@ -42,13 +42,12 @@ module ActivePivot
 
       def send_request(params = {})
         Request.get(endpoint, params).tap do |response|
-          raise_request_error unless response.success?
+          print_request_error unless response.success?
         end
       end
 
-      def raise_request_error
-        raise InvalidRequestError,
-          "Pivotal request failed. Endpoint #{endpoint} invalid with params: #{params}"
+      def print_request_error
+        puts "Pivotal request failed. Endpoint #{endpoint} invalid with params: #{params}"
       end
     end
 

--- a/lib/active_pivot/importer.rb
+++ b/lib/active_pivot/importer.rb
@@ -84,7 +84,7 @@ module ActivePivot
     end
 
     def import_activity(remote_activity)
-      ActivePivot::Activity.new(remote_activity).store
+      ActivePivot::Activity.new(remote_activity).store unless remote_activity['kind'] == "error"
     end
   end
 end

--- a/lib/active_pivot/version.rb
+++ b/lib/active_pivot/version.rb
@@ -1,3 +1,3 @@
 module ActivePivot
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION
Strange errors with activity were popping up and stopping all remaining activity from being imported. I kept getting a different amount of errors every time as well; sometimes 8, sometimes 3, etc. Seems like a failed API request.

This warns the user that an error occurred, but continues importing anyway

(Not a gif, but cute)
![](http://i.imgur.com/gj9V5XJ.jpg)
