### PR TITLE
Fix start date

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ example: `rake active_pivot:import:date['August 12, 2015']`
 `rake active_pivot:import:pivotal_update[]` for all activity since X minutes ago
 example: `rake active_pivot:import:update[15]`
 
+Grabbing the start date of a Story requires sifting through its Activity, which can take a long time.
+If you do not wish to record a Story's start date, use:
+`rake active_pivot:import:update[15,false]`
+
 This gem will create the following models:
 - [ActivePivot::Activity](lib/active_pivot/activity.rb)
 - [ActivePivot::Epic](lib/active_pivot/epic.rb)

--- a/lib/active_pivot/activity.rb
+++ b/lib/active_pivot/activity.rb
@@ -49,7 +49,12 @@ module ActivePivot
     end
 
     def new_values
-      remote_activity.changes[0]['new_values']
+      remote_activity.changes.each do |change|
+        if change['new_values'] && change['new_values']['current_state']
+          return change['new_values']
+        end
+      end
+      return nil
     end
   end
 end

--- a/lib/active_pivot/activity.rb
+++ b/lib/active_pivot/activity.rb
@@ -49,12 +49,13 @@ module ActivePivot
     end
 
     def new_values
-      remote_activity.changes.each do |change|
-        if change['new_values'] && change['new_values']['current_state']
-          return change['new_values']
-        end
+      change['new_values'] if change
+    end
+
+    def change
+      @change ||= remote_activity.changes.detect do |change|
+        change['new_values'] && change['new_values']['current_state']
       end
-      return nil
     end
   end
 end

--- a/lib/active_pivot/import_tasks.rb
+++ b/lib/active_pivot/import_tasks.rb
@@ -5,10 +5,14 @@ module ActivePivot
     def import_tasks
       namespace :active_pivot do
         namespace :import do
-          task :pivotal_update, [:interval] => :environment do |t, args|
+          task :pivotal_update, [:interval, :activity] => :environment do |t, args|
             updated_after = args[:interval].to_i.minutes.ago
+            activity_flag = args[:activity]
             puts "Updating since #{updated_after}"
-            ActivePivot::Importer.run(updated_after)
+            if args[:activity] == 'false'
+              puts "Not including Pivotal Activity for stories (no started_at)"
+            end
+            ActivePivot::Importer.run(updated_after, activity_flag)
           end
 
           task pivotal_initial: :environment do

--- a/lib/active_pivot/importer.rb
+++ b/lib/active_pivot/importer.rb
@@ -1,7 +1,7 @@
 module ActivePivot
-  class Importer < Struct.new(:params)
-    def self.run(updated_after = 5.minutes.ago)
-      self.new({updated_after: updated_after}).run
+  class Importer < Struct.new(:params, :activity_flag)
+    def self.run(updated_after = 5.minutes.ago, activity_flag)
+      self.new({updated_after: updated_after}, activity_flag).run
     end
 
     def run
@@ -11,8 +11,10 @@ module ActivePivot
       import_epics
       puts "Importing Stories"
       import_stories
-      puts "Importing Activity - may take up to 10 minutes"
-      import_activities
+      unless activity_flag == 'false'
+        puts "Importing Activity - may take up to 10 minutes"
+        import_activities
+      end
     end
 
     private

--- a/lib/active_pivot/importer.rb
+++ b/lib/active_pivot/importer.rb
@@ -47,7 +47,7 @@ module ActivePivot
     end
 
     def import_activities
-      Story.all.each do |story|
+      Story.where(started_at: nil).each do |story|
         story.remote_activities(params).each do |remote_activity|
           import_activity(remote_activity)
         end

--- a/lib/active_pivot/version.rb
+++ b/lib/active_pivot/version.rb
@@ -1,3 +1,3 @@
 module ActivePivot
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
Found the error with start dates, some stories have two or more change arrays attached to them. Unsure why. But this searches for the correct one and uses it now.

Also updated so it only imports Activity for Stories that do not have a start date yet. This should cut down on import time immensely. 

Also added Activity flag so we don't have to download it at all if we don't want to.
`rake active_pivot:import:update[15,false]`

![](http://i.imgur.com/JBO7O.gif)
